### PR TITLE
Use the python3 binary defined by the system's environment

### DIFF
--- a/twitchy.py
+++ b/twitchy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Requires: python3, livestreamer, requests
 # rev = 130
 


### PR DESCRIPTION
It's good practice to use **/usr/bin/env python3** in your shebang, instead of hardcoding the path to the python executable. The reason is that different operating systems might install python to different locations. For example, on my distribution (mac OS), python 3 is located in **/usr/local/bin/python3**.

https://askubuntu.com/a/716281