### PR TITLE
add twitchy plugin for py3status

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Features:
 ## Installation
 1. Clone the repository
 2. In the root directory, type:
-    
+
         $ python setup.py build
         # python setup.py install
 
@@ -31,9 +31,9 @@ Please delete `~/.config/twitchy3/*` and restart twitchy before reporting any is
 ## Usage
 
     $ twitchy [ARGUMENT] [OPTIONS]
-    
+
     [ARGUMENT] to the script is used as a search string for channels in the local database.
-    
+
     [OPTIONS]
     -h, --help                      This helpful message
     -a <channel name>               Add channel(s)
@@ -46,27 +46,27 @@ Please delete `~/.config/twitchy3/*` and restart twitchy before reporting any is
     -s <username>                   Sync followed channels from specified account
     -v <channel name>               Watch channel's recorded videos
     -w <channel name>               Watch specified channel(s)
-    
+
     First run:
     Will create both the database and an editable config file in ~/.config/twitchy3/
-    
+
     While playing:
     <q / Ctrl + C> to quit
-    
+
     Run in non-interactive mode. This is useful for integration with dmenu / rofi / conky.
     --non-interactive go            Get customizable comma separated list of channel / game data
     --non-interactive kickstart <>  Start channel directly without asking for confirmation
-    
+
 ## Examples
 
 Using no argument while launching the script will check the status of every channel in the local database:
 ![alt tag](https://i.imgur.com/1Id6J7G.png)
-    
+
 Add channels to local database:
 
     $ twitchy -a bobross <channel2> <channel3> ...
     $ twitchy -s <your twitch username>
-    
+
 Display all strings matching *obr*:
 
     $ twitchy obr
@@ -75,14 +75,14 @@ Display all strings matching *obr*:
     1 bobross                   80085           The Joy of Painting Monday Season 7 Marathon #painting...
     Sonic: Generations
     2 mariobro                  123             #WhereMuhPrincessAt?
-    Wizard Poker                               
+    Wizard Poker
     3 flatulentcobra            6969            Playing secret Paladin. Killing a puppy later.
     Channel number(s): 1-h 2-s 3-l
 
     Custom quality settings: Specify with hyphen next to channel number.
-    E.g. <1-h 2-s 3-l> will simultaneously play 
+    E.g. <1-h 2-s 3-l> will simultaneously play
     channel 1 in high quality, 2 in source quality, and 3 in low quality.
-    
+
 Watch specified channel(s) - Do not have to be in local database:
 
     $ twitchy -w northernlion cobaltstreak
@@ -104,6 +104,16 @@ Supports the excellent [Albert launcher](https://github.com/albertlauncher/alber
 </p>
 
 Move `twitchy_albert.py` in the `plugins` directory to `/usr/share/albert/org.albert.extension.python/modules`
+
+### Py3status
+
+Supports the excellent [py3status](https://github.com/ultrabug/py3status)
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/852504/53009602-84416280-3401-11e9-9f95-c2b2ce58f711.png" />
+</p>
+
+Move `twitchy_py3status.py` in the `plugins` directory to somewhere
+in your py3status module paths as `twitchy.py`.
 
 ### Rofi
 

--- a/plugins/twitchy_py3status.py
+++ b/plugins/twitchy_py3status.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+"""
+Display channels currently streaming on Twitch.tv.
+
+Configuration parameters:
+    button_next: mouse button to display next channel (default 4)
+    button_open: mouse button to open current channel (default 1)
+    button_previous: mouse button to display previous channel (default 5)
+    cache_timeout: refresh interval for this module (default 60)
+    format: display format for this module
+        (default '{format_channel}|No Twitchy')
+    format_channel: display format for this channel
+        *(default "{channelaltname} [\?color=violet {gamealtname}]"
+        "[\?color=darkgray [ {viewers}][ {uptime}]]")*
+    thresholds: specify color thresholds to use (default [])
+
+Format placeholders:
+    {format_channel} format for channels
+    {channel}        total number of channels, eg 10
+
+format_channel placeholders:
+    {gamename}       eg py3status
+    {gamealtname}    eg py3status
+    {channelname}    eg ultrabug
+    {channelaltname} eg Ultrabug
+    {status}         eg I love bugs.
+    {viewers}        eg 55
+    {uptime}         eg 2h25m
+
+    See `NON-INTERACTIVE` in `twitchy.cfg` for a list of Twitchy
+    placeholders to enable. Not all of placeholders will be enabled.
+
+Color thresholds:
+    xxx: print a color based on the value of `xxx` placeholder
+
+Requires:
+    twitchy: cli streamlink wrapper for twitch.tv
+    https://github.com/BasioMeusPuga/twitchy
+
+@author lasers
+"""
+
+from os import path
+from time import time
+
+STRING_NOT_INSTALLED = "not installed"
+
+
+class Py3status:
+    """
+    """
+
+    # available configuration parameters
+    button_next = 4
+    button_open = 1
+    button_previous = 5
+    cache_timeout = 60
+    format = "{format_channel}|No Twitchy"
+    format_channel = (
+        "{channelaltname} [\?color=violet {gamealtname}]"
+        "[\?color=darkgray [ {viewers}][ {uptime}]]"
+    )
+    thresholds = []
+
+    def post_config_hook(self):
+        if not self.py3.check_commands("twitchy"):
+            raise Exception(STRING_NOT_INSTALLED)
+
+        self.active_index = 0
+        self.button_refresh = 2
+        self.channel_data = {}
+        self.delimiter = "|DELIMITER|"
+        self.idle_time = 0
+        self.scrolling = False
+        self.twitchy_command = [
+            "twitchy",
+            "--non-interactive",
+            "--delimiter",
+            self.delimiter,
+        ]
+        self.empty_defaults = {
+            x: None for x in self.py3.get_placeholders_list(self.format)
+        }
+
+        self.placeholders = []
+        with open(path.expanduser("~/.config/twitchy3/twitchy.cfg")) as f:
+            for line in reversed(f.readlines()):
+                if "DisplayScheme =" in line:
+                    placeholders = line.split("=")[-1].lower().split(",")
+                    self.placeholders = [x.strip() for x in placeholders]
+                    break
+
+        self.thresholds_init = {}
+        for name in ["format", "format_channel"]:
+            self.thresholds_init[name] = self.py3.get_color_names_list(
+                getattr(self, name)
+            )
+
+    def _get_twitchy_data(self):
+        try:
+            return self.py3.command_output(self.twitchy_command).strip()
+        except self.py3.CommandError:
+            return ""
+
+    def _manipulate(self, data):
+        new_data = {}
+        for index, line in enumerate(data.splitlines()):
+            channel = dict(zip(self.placeholders, line.split(self.delimiter)))
+            channel["index"] = index + 1
+            if "uptime" in channel:
+                channel["uptime"] = channel["uptime"].replace(" ", "")
+            format_channel = self.py3.safe_format(self.format_channel, channel)
+            self.py3.composite_update(format_channel, {"index": channel["channelname"]})
+
+            for x in self.thresholds_init["format_channel"]:
+                if x in channel:
+                    self.py3.threshold_get_color(channel[x], x)
+            new_data[index] = channel
+
+        return new_data
+
+    def twitchy(self):
+        # refresh
+        current_time = time()
+        refresh = current_time >= self.idle_time
+
+        # time
+        if refresh:
+            self.idle_time = current_time + self.cache_timeout
+            cached_until = self.cache_timeout
+        else:
+            cached_until = self.idle_time - current_time
+
+        # button
+        if self.scrolling and not refresh:
+            self.scrolling = False
+            data = self.channel_data
+        else:
+            data = self._manipulate(self._get_twitchy_data())
+            self.channel_data = data
+
+        if data:
+            self.count_channels = len(data)
+            channel = data.get(self.active_index, {})
+            format_channel = self.py3.safe_format(self.format_channel, channel)
+            self.py3.composite_update(format_channel, {"index": channel["channelname"]})
+
+            twitchy_data = {
+                "format_channel": format_channel,
+                "channel": self.count_channels,
+            }
+
+            for x in self.thresholds_init["format"]:
+                if x in twitchy_data:
+                    self.py3.threshold_get_color(twitchy_data[x], x)
+        else:
+            twitchy_data = self.empty_defaults
+
+        return {
+            "cached_until": self.py3.time_in(cached_until),
+            "full_text": self.py3.safe_format(self.format, twitchy_data),
+        }
+
+    def on_click(self, event):
+        button = event["button"]
+        if button in [self.button_next, self.button_previous]:
+            if self.channel_data:
+                self.scrolling = True
+                if button == self.button_next:
+                    self.active_index += 1
+                elif button == self.button_previous:
+                    self.active_index -= 1
+                self.active_index %= self.count_channels
+            else:
+                self.py3.prevent_refresh()
+        elif button == self.button_refresh:
+            self.idle_time = 0
+        else:
+            if button == self.button_open:
+                index = event["index"]
+                if not isinstance(index, int):
+                    command = "twitchy --non-interactive kickstart {name}"
+                    self.py3.command_run(command.format(name=index))
+            self.py3.prevent_refresh()
+
+
+if __name__ == "__main__":
+    """
+    Run module in test mode.
+    """
+    from py3status.module_test import module_test
+
+    module_test(Py3status)


### PR DESCRIPTION
Hi, I think I will close `add new module: twitchy` pull request on `py3status` because it may not be accepted there and that `twitchy` is not available on repositories other than Arch Linux and GNU Guix https://repology.org/metapackage/twitchy. I think it would make more sense to add the plugin here.

I still will be using this module as I like this more than `twitch` module because it can display more than one channel, name of games, number of viewers, uptime, etc.

If you want me to undo/change something, let me know. Many thanks.

The image is 500x100 to match other screenshot sizes.

![twitchy-feb-2019](https://user-images.githubusercontent.com/852504/53010508-bd7ad200-3403-11e9-9b22-635dbbf453ad.png)


